### PR TITLE
ls to /usr/bin/ls

### DIFF
--- a/manga-cli
+++ b/manga-cli
@@ -91,7 +91,7 @@ download_manga () {
 create_file() {
     if [ $file_format == "pdf" ]
     then 
-        convert $(ls -v $image_dir*.jpg) "$image_dir$name-$chapterNumber.pdf" 
+        convert $(/usr/bin/ls -v $image_dir*.jpg) "$image_dir$name-$chapterNumber.pdf" 
         rm $image_dir/*.jpg
         clear
         zathura "$image_dir$name-$chapterNumber.pdf" &
@@ -227,4 +227,3 @@ while [ "$1" != "" ]; do
 done
 
 download_manga
-


### PR DESCRIPTION
Changed `ls` to '/usr/bin/ls' this will allow for people to use aliases on ls. For example if I have an alias of `alias ls = "ls -al --color"` then this script wont work but with this change it will